### PR TITLE
remove g++ build dependency to allow cross-build

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,6 @@ Section: misc
 Priority: optional
 Standards-Version: 3.9.2
 Build-Depends: debhelper (>= 10),
-               g++,
                libjsoncpp-dev,
                libmosquitto-dev,
                libmosquittopp-dev,


### PR DESCRIPTION
as per https://www.debian.org/doc/manuals/maint-guide/dreq.ru.html,
"Some packages like gcc and make which are required by the build-essential package are implied"